### PR TITLE
Some fixes in messages passing

### DIFF
--- a/src/main/scala/de/kp/insight/collect/CollectorApp.scala
+++ b/src/main/scala/de/kp/insight/collect/CollectorApp.scala
@@ -98,7 +98,7 @@ object CollectorApp extends CollectorService {
        
       }
     
-      case msg:PrepareFailed => {
+      case msg:CollectFailed => {
     
         val end = new java.util.Date().getTime           
         println("Collector failed at " + end)
@@ -107,7 +107,7 @@ object CollectorApp extends CollectorService {
       
       }
     
-      case msg:PrepareFinished => {
+      case msg:CollectFinished => {
     
         val model = msg.data(Names.REQ_MODEL)
         BUF += model

--- a/src/main/scala/de/kp/insight/collect/CollectorApp.scala
+++ b/src/main/scala/de/kp/insight/collect/CollectorApp.scala
@@ -44,7 +44,7 @@ object CollectorApp extends CollectorService {
       val actor = system.actorOf(Props(new Handler(ctx,req_params)))   
       inbox.watch(actor)
     
-      actor ! StartCollect
+      actor ! StartCollect()
 
       val timeout = DurationInt(30).minute
     
@@ -86,7 +86,7 @@ object CollectorApp extends CollectorService {
         val csm_params = params ++ Map(Names.REQ_NAME -> "CSM")
         
         val csm_collector = context.actorOf(Props(new CSMCollector(ctx,csm_params))) 
-        csm_collector ! StartCollect
+        csm_collector ! StartCollect()
         
         /*
          * Start PRDCollector
@@ -94,7 +94,7 @@ object CollectorApp extends CollectorService {
         val prd_params = params ++ Map(Names.REQ_NAME -> "PRD")
         
         val prd_collector = context.actorOf(Props(new PRDCollector(ctx,prd_params))) 
-        prd_collector ! StartCollect
+        prd_collector ! StartCollect()
        
       }
     
@@ -129,7 +129,7 @@ object CollectorApp extends CollectorService {
           val ord_params = params ++ Map(Names.REQ_NAME -> "ORD")
         
           val ord_collector = context.actorOf(Props(new CSMCollector(ctx,ord_params))) 
-          ord_collector ! StartCollect
+          ord_collector ! StartCollect()
           
         }
         

--- a/src/main/scala/de/kp/insight/collect/CollectorJob.scala
+++ b/src/main/scala/de/kp/insight/collect/CollectorJob.scala
@@ -89,7 +89,7 @@ object CollectorJob extends CollectorService {
        
       }
     
-      case msg:PrepareFailed => {
+      case msg:CollectFailed => {
     
         val end = new java.util.Date().getTime           
         println("Collector failed at " + end)
@@ -98,7 +98,7 @@ object CollectorJob extends CollectorService {
       
       }
     
-      case msg:PrepareFinished => {
+      case msg:CollectFinished => {
     
         val end = new java.util.Date().getTime           
         println("Collector finished at " + end)

--- a/src/main/scala/de/kp/insight/collect/CollectorJob.scala
+++ b/src/main/scala/de/kp/insight/collect/CollectorJob.scala
@@ -44,7 +44,7 @@ object CollectorJob extends CollectorService {
       val actor = system.actorOf(Props(new Handler(ctx,req_params)))   
       inbox.watch(actor)
     
-      actor ! StartCollect
+      actor ! StartCollect()
 
       val timeout = DurationInt(30).minute
     
@@ -85,7 +85,7 @@ object CollectorJob extends CollectorService {
           
         }
 
-        collector ! StartCollect
+        collector ! StartCollect()
        
       }
     

--- a/src/main/scala/de/kp/insight/enrich/EnricherApp.scala
+++ b/src/main/scala/de/kp/insight/enrich/EnricherApp.scala
@@ -67,7 +67,7 @@ object EnricherApp extends EnricherService("Enricher") {
       val actor = system.actorOf(Props(new Handler(ctx,req_params)))   
       inbox.watch(actor)
     
-      actor ! StartLearn
+      actor ! StartLearn()
 
       val timeout = DurationInt(30).minute
     
@@ -122,7 +122,7 @@ object EnricherApp extends EnricherService("Enricher") {
           
         }
         
-        builder ! StartLearn
+        builder ! StartLearn()
        
       }
     

--- a/src/main/scala/de/kp/insight/flow/RFMFlow.scala
+++ b/src/main/scala/de/kp/insight/flow/RFMFlow.scala
@@ -78,7 +78,7 @@ object RFMFlow extends SparkService {
       val actor = system.actorOf(Props(new Handler(ctx,params,orders)))   
       inbox.watch(actor)
     
-      actor ! StartPrepare
+      actor ! StartPrepare()
 
       val timeout = DurationInt(30).minute
     
@@ -109,7 +109,7 @@ object RFMFlow extends SparkService {
         registerPrepare(params)        
         val preparer = context.actorOf(Props(new RFMPreparer(ctx,params,orders))) 
         
-        preparer ! StartPrepare
+        preparer ! StartPrepare()
        
       }
     
@@ -130,7 +130,7 @@ object RFMFlow extends SparkService {
         registerLoad(params)
         val loader = context.actorOf(Props(new RFMLoader(ctx,params))) 
         
-        loader ! StartLoad
+        loader ! StartLoad()
         
       }
     

--- a/src/main/scala/de/kp/insight/learn/LearnerApp.scala
+++ b/src/main/scala/de/kp/insight/learn/LearnerApp.scala
@@ -54,7 +54,7 @@ object LearnerApp extends LearnerService("Learner") {
       val actor = system.actorOf(Props(new Handler(ctx,req_params)))   
       inbox.watch(actor)
     
-      actor ! StartLearn
+      actor ! StartLearn()
 
       val timeout = DurationInt(30).minute
     
@@ -105,7 +105,7 @@ object LearnerApp extends LearnerService("Learner") {
           
         }
         
-        builder ! StartLearn
+        builder ! StartLearn()
        
       }
     

--- a/src/main/scala/de/kp/insight/predict/PredictorApp.scala
+++ b/src/main/scala/de/kp/insight/predict/PredictorApp.scala
@@ -46,7 +46,7 @@ object PredictorApp extends PredictorService("Predictor") {
       val actor = system.actorOf(Props(new Handler(ctx,req_params)))   
       inbox.watch(actor)
     
-      actor ! StartPredict
+      actor ! StartPredict()
 
       val timeout = DurationInt(30).minute
     
@@ -85,7 +85,7 @@ object PredictorApp extends PredictorService("Predictor") {
           
         }
         
-        loader ! StartPredict
+        loader ! StartPredict()
        
       }
     

--- a/src/main/scala/de/kp/insight/prepare/PreparerApp.scala
+++ b/src/main/scala/de/kp/insight/prepare/PreparerApp.scala
@@ -73,7 +73,7 @@ object PreparerApp extends PreparerService("Preparer") {
       val actor = system.actorOf(Props(new Handler(ctx,req_params,orders)))   
       inbox.watch(actor)
     
-      actor ! StartPrepare
+      actor ! StartPrepare()
 
       val timeout = DurationInt(30).minute
     
@@ -134,7 +134,7 @@ object PreparerApp extends PreparerService("Preparer") {
           
         }
         
-        preparer ! StartPrepare
+        preparer ! StartPrepare()
        
       }
     

--- a/src/main/scala/de/kp/insight/profile/ProfilerApp.scala
+++ b/src/main/scala/de/kp/insight/profile/ProfilerApp.scala
@@ -46,7 +46,7 @@ object ProfilerApp extends ProfilerService("Profiler") {
       val actor = system.actorOf(Props(new Handler(ctx,req_params)))   
       inbox.watch(actor)
     
-      actor ! StartProfile
+      actor ! StartProfile()
 
       val timeout = DurationInt(30).minute
     
@@ -83,7 +83,7 @@ object ProfilerApp extends ProfilerService("Profiler") {
           
         }
         
-        loader ! StartProfile
+        loader ! StartProfile()
        
       }
     

--- a/src/main/scala/de/kp/insight/storage/LoaderApp.scala
+++ b/src/main/scala/de/kp/insight/storage/LoaderApp.scala
@@ -63,7 +63,7 @@ object LoaderApp extends LoaderService("Loader") {
       val actor = system.actorOf(Props(new Handler(ctx,req_params)))   
       inbox.watch(actor)
     
-      actor ! StartLoad
+      actor ! StartLoad()
 
       val timeout = DurationInt(30).minute
     
@@ -130,7 +130,7 @@ object LoaderApp extends LoaderService("Loader") {
           
         }
         
-        loader ! StartLoad
+        loader ! StartLoad()
        
       }
     


### PR DESCRIPTION
As mentioned here: http://stackoverflow.com/questions/2254710/why-were-the-case-classes-without-a-parameter-list-deprecated, 
calling 'StartCollect' will reference the companion object of the case class StartCollect.
We must create a instance of it by calling apply on the companion object: "StartCollect()".

The message in the Collect phase was wrong, it should be: 
- StartCollect
- CollectFailed
- CollectFinished
